### PR TITLE
(feat) Add package deps and tests for mod_apreq2 on Debian 9, 10

### DIFF
--- a/manifests/mod/apreq2.pp
+++ b/manifests/mod/apreq2.pp
@@ -3,7 +3,7 @@
 #
 # @see http://httpd.apache.org/apreq/docs/libapreq2/group__mod__apreq2.html for additional documentation.
 #
-
+# @note Unsupported platforms: CentOS: all; Debian: 8; OracleLinux: all; RedHat: all; Scientific: all; SLES: all; Ubuntu: all
 class apache::mod::apreq2 {
   ::apache::mod { 'apreq2':
     id => 'apreq_module',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -389,6 +389,7 @@ class apache::params inherits ::apache::version {
         default => '7.2', # Ubuntu Bionic, Cosmic and Disco
       }
       $mod_packages = {
+        'apreq2'                => 'libapache2-mod-apreq2',
         'auth_cas'              => 'libapache2-mod-auth-cas',
         'auth_kerb'             => 'libapache2-mod-auth-kerb',
         'auth_openidc'          => 'libapache2-mod-auth-openidc',

--- a/spec/acceptance/mod_apreq2_spec.rb
+++ b/spec/acceptance/mod_apreq2_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper_acceptance'
+apache_hash = apache_settings_hash
+
+describe 'apache::mod::apreq2', if: mod_supported_on_platform?('apache::mod::apreq2') do
+  pp = <<-MANIFEST
+    class { 'apache' : }
+    class { 'apache::mod::apreq2': }
+  MANIFEST
+
+  it 'succeeds in installing the mod_authnz_apreq2 module' do
+    apply_manifest(pp, catch_failures: true)
+  end
+end


### PR DESCRIPTION
This commit ensures that the required package for the `apreq2` MOD
is installed on Debian 9 and 10.

Also adds a basic acceptance test for this MOD on those platforms.